### PR TITLE
chore: target Android API 37 and migrate to AGP 9

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -14,9 +14,10 @@
  * limitations under the License.
  */
 
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+
 plugins {
     alias(libs.plugins.android.application)
-    alias(libs.plugins.jetbrains.kotlin.android)
     alias(libs.plugins.kotlin.compose)
     alias(libs.plugins.ksp)
     alias(libs.plugins.hilt)
@@ -30,7 +31,7 @@ val overrideVersionName: String? = project.findProperty("versionName") as? Strin
 
 android {
     namespace = "com.criticalay.neer"
-    compileSdk = 36
+    compileSdk = 37
 
     signingConfigs {
         create("release") {
@@ -47,7 +48,7 @@ android {
     defaultConfig {
         applicationId = "com.criticalay.neer"
         minSdk = 25
-        targetSdk = 36
+        targetSdk = 37
 
         // The version number is of the form:
         // <major>.<minor>.<maintenance>[dev|alpha<build>|beta<build>|]
@@ -106,9 +107,6 @@ android {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
     }
-    kotlinOptions {
-        jvmTarget = "17"
-    }
     buildFeatures {
         compose = true
         buildConfig = true
@@ -117,6 +115,14 @@ android {
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
+    }
+}
+
+// AGP 9 provides Kotlin support built in, so the jvmTarget that used to live in
+// android { kotlinOptions } is configured through the kotlin extension instead.
+kotlin {
+    compilerOptions {
+        jvmTarget = JvmTarget.JVM_17
     }
 }
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -17,7 +17,6 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 plugins {
     alias(libs.plugins.android.application) apply false
-    alias(libs.plugins.jetbrains.kotlin.android) apply false
     alias(libs.plugins.ksp) apply false
     alias(libs.plugins.kotlin.compose) apply false
     alias(libs.plugins.hilt) apply false

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -7,7 +7,6 @@ desugar_jdk_libs_nio = "2.1.5"
 glance = "1.1.1"
 ktlint = "14.2.0"
 hiltAndroid = "2.60.1"
-kotlin = "2.4.10"
 ksp = "2.3.11"
 coreKtx = "1.19.0"
 junit = "4.13.2"
@@ -61,7 +60,6 @@ androidx-glance-material3 = { group = "androidx.glance", name = "glance-material
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
-jetbrains-kotlin-android = { id = "org.jetbrains.kotlin.android", version.ref = "kotlin" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 kotlin-compose = { id = "org.jetbrains.kotlin.plugin.compose", version.ref = "composeCompiler" }
 hilt = { id = "com.google.dagger.hilt.android", version.ref = "hiltAndroid" }


### PR DESCRIPTION
## Purpose / Description

Moves the app to Android API 37 (Android 17), and repairs the build along the way.

While bumping the SDK it turned out `master` does not build at all. Dependabot bumped AGP 8.13.2 to 9.2.1 to 9.3.1 (#38, #47) without the migration that a major AGP release requires. AGP 9 ships Kotlin support built in and now hard errors on the standalone Kotlin plugin:

```
> Failed to apply plugin 'org.jetbrains.kotlin.android'
  The 'org.jetbrains.kotlin.android' plugin is no longer required for Kotlin
  support since AGP 9.0.
```

This was reproduced on a clean checkout of `master` with no other changes applied, so it is pre-existing and not a side effect of the SDK bump. The SDK bump cannot be verified without fixing it, so both are here.

## Fixes

* Restores a buildable `master` after the AGP 9 dependabot bumps (#38, #47)

## Approach

**SDK bump**
* `compileSdk` and `targetSdk` 36 to 37

**AGP 9 migration**
* Remove `org.jetbrains.kotlin.android` from the app and root build files, since AGP 9 provides Kotlin support itself
* Move `jvmTarget` out of the removed `android { kotlinOptions }` block into the `kotlin { compilerOptions }` extension
* Drop the `jetbrains-kotlin-android` plugin alias and the `kotlin` version it referenced, both orphaned by the above

Kotlin still resolves to 2.4.10 through the Compose compiler plugin, so the toolchain version is unchanged. Verified with `:app:dependencies`. Dependabot's `kotlin` group matches on coordinate patterns (`org.jetbrains.kotlin*`, `com.google.devtools.ksp`) rather than catalog alias names, so removing the alias does not affect its grouping.

## How Has This Been Tested?

All from a clean state (`./gradlew clean`) on AGP 9.3.1 / Gradle 9.6.1 / JDK 22, macOS:

| Task | Result |
| --- | --- |
| `:app:assembleDebug` | pass |
| `:app:assembleRelease` (R8 / minify) | pass |
| `:app:testDebugUnitTest` | pass |
| `ktlintCheck` | pass |

Artifacts confirmed via `aapt2 dump badging`, both variants:

```
compileSdkVersion='37' compileSdkVersionCodename='17'
targetSdkVersion:'37'
```

AGP no longer emits the "we recommend using a newer Android Gradle plugin" warning that 8.13.2 produced for compile SDK 37, since 9.3.1 supports it natively.

Not tested on device or emulator. Android 17 runtime behaviour changes that come with raising `targetSdk` are worth a manual pass before release, particularly around the exact alarms, notifications, boot receiver and Glance widgets this app relies on.

## Notes for the reviewer

`gradlew.bat` shows as permanently modified in the working tree on `master`. `.gitattributes` declares `*.bat text` (LF) but the committed blob has CRLF line endings, so git flags it dirty until someone runs `git add --renormalize gradlew.bat`. It is unrelated to this change and deliberately left out of this PR.

## Checklist

- [x] You have a descriptive commit message with a short title (first line, max 50 chars).
- [x] You have commented your code, particularly in hard-to-understand areas
- [x] You have performed a self-review of your own code
- [ ] UI changes: include screenshots of all affected screens (in particular showing any new or changed strings)
- [ ] UI Changes: You have tested your change using the Google Accessibility Scanner

No UI changes in this PR, so the UI items do not apply.
