### PR TITLE
chore: harden release builds for IzzyOnDroid/F-Droid

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -107,6 +107,17 @@ jobs:
 
           echo "Building $TAG (versionCode=$VERSION_CODE)"
 
+      - name: Check for a F-Droid/IzzyOnDroid changelog
+        shell: bash
+        run: |
+          CHANGELOG="fastlane/metadata/android/en-US/changelogs/${{ steps.v.outputs.version_code }}.txt"
+          if [ -f "$CHANGELOG" ]; then
+            echo "Found $CHANGELOG:"
+            cat "$CHANGELOG"
+          else
+            echo "::warning::No $CHANGELOG — IzzyOnDroid/F-Droid will show no release notes for this build. Add one and re-run if that matters."
+          fi
+
       - name: Set up JDK 17
         uses: actions/setup-java@v5.6.0
         with:

--- a/README.md
+++ b/README.md
@@ -17,6 +17,14 @@ Install
 
 </div>
 
+## Releases and signing
+Neer is developed by Ashish Yadav — [hiashish.com](https://hiashish.com/).
+Releases are built, signed, and published by the [release workflow](.github/workflows/release.yml) in this repository.
+
+> **Signing key change in v2.00.00:** the original signing key was lost and had to be replaced.
+> Android will not install an update signed with a different key, so if you have a build older than
+> v2.00.00 you need to uninstall it before you can update and keep receiving future updates.
+
 ## Features
 * Water Intake Reminder: Receive timely notifications reminding you to drink water regularly.
 * Customizable Goals: Set your daily water intake goals based on your preferences and needs.

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -111,7 +111,20 @@ android {
         compose = true
         buildConfig = true
     }
+
+    // AGP embeds an encrypted dependency tree in the APK signing block that only
+    // Google can read, so nobody else can verify what it contains. F-Droid and
+    // IzzyOnDroid flag it (DEPENDENCY_INFO_BLOCK, 0x504b4453) — leave it out.
+    dependenciesInfo {
+        includeInApk = false
+        includeInBundle = false
+    }
+
     packaging {
+        // Stripping debug symbols bakes the local NDK version into the .so files
+        // we ship (androidx.graphics.path, datastore), which breaks reproducible
+        // builds for anyone without that exact NDK. Ship them unstripped instead.
+        jniLibs.keepDebugSymbols.add("**/*.so")
         resources {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }

--- a/fastlane/metadata/android/en-US/changelogs/20000300.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20000300.txt
@@ -1,0 +1,1 @@
+!! Signing key has changed, so you need to uninstall any previous version to be able to update and receive future updates !!

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -18,5 +18,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
+distributionSha256Sum=9c0f7faeeb306cb14e4279a3e084ca6b596894089a0638e68a07c945a32c9e14
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Addresses the actionable items IzzySoft raised in #30 after the v2.00.00 signing key rotation.

### Drop the Google dependency blob

AGP embeds a `DEPENDENCY_INFO_BLOCK` (`0x504b4453`) in the APK signing block. It is encrypted to a Google key, so no third party can verify what it contains, and IzzyOnDroid's scanner flags it. `dependenciesInfo { includeInApk = false; includeInBundle = false }` leaves it out.

Verified on a locally built release APK:

```
before                                    after
0x7109871A   1,390B  SIG_SCHEME_V2        0x7109871A   1,390B  SIG_SCHEME_V2
0x504B4453   8,335B  DEPENDENCY_INFO      0x42726577   2,650B  PADDING
0x42726577   2,495B  PADDING
```

### Pin the Gradle distribution checksum

`distributionSha256Sum` for `gradle-9.6.1-bin.zip`, cross-checked against both `services.gradle.org/distributions/gradle-9.6.1-bin.zip.sha256` and gradle.org/release-checksums. Confirmed the wrapper enforces it: the real sum downloads and verifies, a deliberately wrong one aborts with *"Verification of Gradle distribution failed!"*. Dependabot's wrapper updater keeps this in sync on future bumps.

### Keep native debug symbols

`jniLibs.keepDebugSymbols.add("**/*.so")`, as requested — stripping bakes the builder's NDK version into the two `.so` files we ship (`androidx.graphics.path`, `datastore`), which is why rebuilding v2.00.00 needed NDK 27 while the GitHub runners carry 28.2.

Worth being precise about what this buys us today: v2.00.00 was built with **AGP 8.13.2**, where the strip task actively strips. On AGP 9.3.1 (this branch) I forced `stripReleaseDebugSymbols` to re-run with and without the line and the output was byte-identical either way — `libandroidx.graphics.path.so` already ships stripped upstream, and `libdatastore_shared_counter.so` comes through untouched. So on the current toolchain this is belt-and-braces rather than a behaviour change, but it makes NDK-independence explicit and survives future AGP or toolchain changes.

### Changelogs

Adds `fastlane/metadata/android/en-US/changelogs/20000300.txt` with the signing-key warning IzzySoft had to write by hand, and a non-failing workflow step that warns when a release has no changelog for its computed versionCode.

### README

Records the current website (hiashish.com — the previously recorded `www.criticalay.me` is NXDOMAIN) and the v2.00.00 key rotation, so the recovery channel on file actually resolves.

---

### Not in this PR

- **Build releases via the Release workflow, not locally.** This is the main remaining reproducibility item and it is a process change, not a code one. The published v2.00.00 came off a local machine (NDK 27, JDK 22) rather than the runner (NDK 28.2, Temurin 17); R8 running on a different JDK is the leading suspect for the remaining `classes.dex` diff.
- **`-dontobfuscate`.** Only worth trying if the dex diff survives the above — IzzySoft reports it resolved the same symptom for two other apps.
- **Signed tags / published GPG fingerprint.** The rollover only worked because the email channel survived; there is currently no second verifiable recovery path.

Verified locally: `:app:assembleRelease` and `:app:ktlintCheck` both green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
