### PR TITLE
chore(release): fix the release workflow and prepare 2.01.00

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,17 +2,23 @@
 #
 # Triggered from the Actions tab → "Release" → "Run workflow". Collects the
 # version parts + release type, computes the versionCode per the app's scheme
-# (AbbCCtDD), builds a release APK (signed with the keystore from secrets
-# if configured, otherwise the debug key as a fallback), tags the commit,
-# and publishes a GitHub Release with the APK attached. Alpha and beta
-# releases are marked as pre-release.
+# (AbbCCtDD), runs the checks, builds a signed release APK, verifies the APK
+# really carries our release certificate, tags the commit, and publishes a
+# GitHub Release with the APK attached. Alpha and beta releases are marked as
+# pre-release.
 #
-# Required repo secrets for production signing (optional — skip for debug-
-# signed APKs):
+# Required repo secrets — the workflow fails fast if any are missing, because
+# a release signed with the debug key cannot be installed as an update by
+# anyone who already has the app, and IzzyOnDroid/F-Droid will reject it:
 #   SIGNING_KEY         — base64-encoded contents of your .jks keystore file
 #   KEYSTORE_PASSWORD   — keystore password
 #   KEY_ALIAS           — signing key alias
 #   KEY_PASSWORD        — signing key password
+#
+# Reproducibility: the runner image and JDK are pinned, and the build
+# environment is recorded in the release notes, so IzzyOnDroid can attempt a
+# reproducible build against the same toolchain. Always release from here —
+# never upload a locally built APK (see #30).
 
 name: Release
 
@@ -22,11 +28,11 @@ on:
       major:
         description: "Major version (1 digit)"
         type: string
-        default: "1"
+        default: "2"
       minor:
         description: "Minor version (2 digits, zero-padded)"
         type: string
-        default: "03"
+        default: "01"
       patch:
         description: "Patch / maintenance version (2 digits, zero-padded)"
         type: string
@@ -47,13 +53,47 @@ on:
 permissions:
   contents: write
 
+# Two releases building at once would race on the tag push.
+concurrency:
+  group: release
+  cancel-in-progress: false
+
+env:
+  # SHA-256 of the certificate our release key produces, as recorded by
+  # IzzyOnDroid's scanner in #30 after the April 2026 key rotation. The build
+  # fails if the APK we are about to publish is signed by anything else — that
+  # is the check which would have caught the 2.00.00 rejection before shipping.
+  # If the key is ever rotated again, update this value and notify IzzySoft.
+  EXPECTED_CERT_SHA256: "6248657a9f292d32f4086f3580a6b945c06d0a7a4108d6d37254afe3dc1aea3e"
+
 jobs:
   release:
     name: Build & publish
-    runs-on: ubuntu-latest
+    # Pinned rather than ubuntu-latest: a moving runner image changes the
+    # toolchain under us, which breaks reproducible builds.
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out source
         uses: actions/checkout@v7
+
+      - name: Verify signing secrets are present
+        env:
+          SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
+          KEYSTORE_PASSWORD: ${{ secrets.KEYSTORE_PASSWORD }}
+          KEY_ALIAS: ${{ secrets.KEY_ALIAS }}
+          KEY_PASSWORD: ${{ secrets.KEY_PASSWORD }}
+        shell: bash
+        run: |
+          missing=()
+          [ -n "$SIGNING_KEY" ]       || missing+=(SIGNING_KEY)
+          [ -n "$KEYSTORE_PASSWORD" ] || missing+=(KEYSTORE_PASSWORD)
+          [ -n "$KEY_ALIAS" ]         || missing+=(KEY_ALIAS)
+          [ -n "$KEY_PASSWORD" ]      || missing+=(KEY_PASSWORD)
+          if [ ${#missing[@]} -gt 0 ]; then
+            echo "::error::Missing release signing secrets: ${missing[*]}. Refusing to publish a debug-signed release."
+            exit 1
+          fi
+          echo "All four signing secrets are present."
 
       - name: Compute version fields
         id: v
@@ -64,6 +104,16 @@ jobs:
           PATCH="${{ inputs.patch }}"
           TYPE="${{ inputs.release_type }}"
           BUILD="${{ inputs.build }}"
+
+          # Reject anything that would silently overflow the AbbCCtDD scheme.
+          # A 9-digit versionCode is still a valid Android versionCode, so it
+          # would ship and permanently break upgrade ordering.
+          [[ "$MAJOR" =~ ^[0-9]$ ]]      || { echo "::error::major must be a single digit 0-9, got '$MAJOR'"; exit 1; }
+          [[ "$MINOR" =~ ^[0-9]{1,2}$ ]] || { echo "::error::minor must be 1-2 digits, got '$MINOR'"; exit 1; }
+          [[ "$PATCH" =~ ^[0-9]{1,2}$ ]] || { echo "::error::patch must be 1-2 digits, got '$PATCH'"; exit 1; }
+          if [ "$TYPE" != "stable" ]; then
+            [[ "$BUILD" =~ ^[0-9]{1,2}$ ]] || { echo "::error::build must be 1-2 digits for alpha/beta, got '$BUILD'"; exit 1; }
+          fi
 
           # Zero-pad minor/patch/build to the widths required by the versionCode scheme.
           MINOR=$(printf "%02d" "$((10#$MINOR))")
@@ -94,6 +144,11 @@ jobs:
           VERSION_CODE="${MAJOR}${MINOR}${PATCH}${T_DIGIT}${BUILD_PAD}"
           TAG="v${VERSION_NAME}"
 
+          if [ "${#VERSION_CODE}" -ne 8 ]; then
+            echo "::error::versionCode '$VERSION_CODE' is not 8 digits — the AbbCCtDD scheme was violated"
+            exit 1
+          fi
+
           if [ "$TYPE" = "stable" ]; then
             PRERELEASE=false
           else
@@ -106,6 +161,17 @@ jobs:
           echo "prerelease=$PRERELEASE"     >> "$GITHUB_OUTPUT"
 
           echo "Building $TAG (versionCode=$VERSION_CODE)"
+
+      - name: Check the tag is free
+        shell: bash
+        run: |
+          # Fail before spending a build on a version that is already released,
+          # and before the tag push at the end fails and leaves a half-run.
+          if git ls-remote --exit-code --tags origin "refs/tags/${{ steps.v.outputs.tag }}" >/dev/null 2>&1; then
+            echo "::error::Tag ${{ steps.v.outputs.tag }} already exists on origin. Bump the version or delete the tag first."
+            exit 1
+          fi
+          echo "Tag ${{ steps.v.outputs.tag }} is free."
 
       - name: Check for a F-Droid/IzzyOnDroid changelog
         shell: bash
@@ -127,17 +193,15 @@ jobs:
       - name: Set up Gradle
         uses: gradle/actions/setup-gradle@v6
 
+      - name: Run checks
+        run: ./gradlew :app:ktlintCheck :app:testDebugUnitTest
+
       - name: Decode signing keystore
         id: keystore
         env:
           SIGNING_KEY: ${{ secrets.SIGNING_KEY }}
         shell: bash
         run: |
-          if [ -z "$SIGNING_KEY" ]; then
-            echo "::warning::SIGNING_KEY secret is not set — building with debug key."
-            echo "path=" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
           echo "$SIGNING_KEY" | base64 --decode > "$RUNNER_TEMP/release.jks"
           echo "path=$RUNNER_TEMP/release.jks" >> "$GITHUB_OUTPUT"
 
@@ -165,6 +229,58 @@ jobs:
           cp "$APK_SRC" "$APK_DEST"
           echo "path=$APK_DEST" >> "$GITHUB_OUTPUT"
 
+          MAPPING="app/build/outputs/mapping/release/mapping.txt"
+          if [ -f "$MAPPING" ]; then
+            gzip -c "$MAPPING" > "neer-${{ steps.v.outputs.version_name }}-mapping.txt.gz"
+            echo "mapping=neer-${{ steps.v.outputs.version_name }}-mapping.txt.gz" >> "$GITHUB_OUTPUT"
+          else
+            echo "::warning::No R8 mapping.txt found — crash reports for this build cannot be deobfuscated"
+          fi
+
+      - name: Verify APK signature
+        shell: bash
+        run: |
+          APKSIGNER=$(find "$ANDROID_HOME/build-tools" -name apksigner -type f | sort -V | tail -n 1)
+          if [ -z "$APKSIGNER" ]; then
+            echo "::error::apksigner not found under $ANDROID_HOME/build-tools"
+            exit 1
+          fi
+
+          "$APKSIGNER" verify --print-certs --verbose "${{ steps.apk.outputs.path }}"
+
+          ACTUAL=$("$APKSIGNER" verify --print-certs "${{ steps.apk.outputs.path }}" \
+            | grep -m1 "certificate SHA-256 digest" | awk '{print $NF}')
+
+          echo "Signing certificate SHA-256: $ACTUAL"
+          if [ "$ACTUAL" != "$EXPECTED_CERT_SHA256" ]; then
+            echo "::error::APK is signed by the wrong certificate."
+            echo "::error::expected $EXPECTED_CERT_SHA256"
+            echo "::error::actual   $ACTUAL"
+            echo "::error::Refusing to publish — IzzyOnDroid/F-Droid would quarantine this build and existing users could not update."
+            exit 1
+          fi
+          echo "Signing certificate matches the registered release key."
+
+      - name: Record build environment
+        id: env
+        shell: bash
+        run: |
+          {
+            echo "env<<EOF"
+            echo "<details><summary>Build environment (for reproducible builds)</summary>"
+            echo
+            echo '```'
+            echo "runner image : $ImageOS ($(. /etc/os-release && echo "$PRETTY_NAME"))"
+            echo "jdk          : $(java -version 2>&1 | head -n 1)"
+            echo "gradle       : $(./gradlew --version | awk '/^Gradle /{print $2}')"
+            echo "agp          : $(grep -E '^agp' gradle/libs.versions.toml | cut -d'"' -f2)"
+            echo "commit       : $GITHUB_SHA"
+            echo '```'
+            echo
+            echo "</details>"
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+
       - name: Create and push tag
         shell: bash
         run: |
@@ -181,4 +297,7 @@ jobs:
           name: Neer ${{ steps.v.outputs.version_name }}
           prerelease: ${{ steps.v.outputs.prerelease == 'true' }}
           generate_release_notes: true
-          files: ${{ steps.apk.outputs.path }}
+          body: ${{ steps.env.outputs.env }}
+          files: |
+            ${{ steps.apk.outputs.path }}
+            ${{ steps.apk.outputs.mapping }}

--- a/fastlane/metadata/android/en-US/changelogs/20100300.txt
+++ b/fastlane/metadata/android/en-US/changelogs/20100300.txt
@@ -1,0 +1,9 @@
+Maintenance release — no changes to how the app works.
+
+- Now targets Android API 37
+- Release builds no longer embed Google's encrypted dependency-info blob
+- The Gradle distribution used to build Neer is now checksum-pinned
+- The privacy policy documents what data is kept on your device and how to delete it
+- Updated Compose, AndroidX, Kotlin, Hilt and Room
+
+The signing key is unchanged from 2.00.00, so this updates normally.


### PR DESCRIPTION
Prepares the 2.01.00 release and fixes the release workflow first, because auditing it turned up that **it has never actually released anything**.

> [!NOTE]
> Supersedes #50, which was merged into `chore/izzyondroid-build-hardening` rather than `master`, so these changes never reached master. Same commit, rebased onto master; `chore/izzyondroid-build-hardening` is now redundant and can be deleted.

### What the audit found

The workflow has run exactly twice, both on 2026-04-20, and neither produced a real release:

| Tag | Tagger | Points at | Release |
|---|---|---|---|
| `v1.02.00` | `github-actions[bot]` | `b77c11a setup ktlint format` | none — orphan |
| `v1.03.00` | `github-actions[bot]` | `b77c11a setup ktlint format` | none — orphan |
| `v2.00.00` | **Ashish Yadav**, 02:04:50Z | `63f6bb7 update -v to 2.0.0` | asset `app-release.apk` |

The two bot tags are the workflow being smoke-tested with its stale default inputs (`major: "1"`, `minor: "03"`) — still on origin, pointing at an unrelated commit. v2.00.00 was then tagged by hand 40 minutes later, and its asset is `app-release.apk`, not the `neer-<version>.apk` this workflow produces.

So the APK IzzyOnDroid quarantined in #30 never went through CI. That corroborates IzzySoft's NDK-27 deduction from an independent direction.

### Fixes

**A missing signing secret silently published a debug-signed APK.** The old workflow emitted only a `::warning::` and carried on; [`build.gradle.kts`](app/build.gradle.kts#L93) then falls back to the debug key. A rotated or expired secret would ship a release no existing user could update to and IzzyOnDroid would reject — #30 all over again, silently. Confirmed the hazard is live: `apksigner` on a local release build reports `CN=Android Debug`.

Now: fails fast if any of the four secrets is missing, **and** verifies the built APK's signing certificate against the fingerprint IzzyOnDroid has on file, refusing to publish on mismatch. That is the check that would have caught the 2.00.00 quarantine before shipping.

**Version inputs were unvalidated.** `major=10` or `build=100` produced a 9-digit versionCode. That is still a *valid* Android versionCode, so it would have shipped and permanently broken upgrade ordering:

```
before                                   after
(10,01,00,stable) -> code=100100300      ::error::major must be a single digit 0-9, got '10'
(2,01,00,beta,100) -> code=201002100     ::error::build must be 1-2 digits for alpha/beta, got '100'
```

Plus: fail before building if the tag already exists (so a re-run after a partial failure reports the real problem instead of dying at the tag push); run `ktlintCheck` and unit tests as a gate; pin `ubuntu-24.04` instead of `ubuntu-latest` and record the build environment in the release notes, both for reproducible builds; a `concurrency` group so two releases can't race on the tag push; the stale input defaults corrected to 2/01/00; and the R8 mapping attached so obfuscated crash reports can be read and IzzySoft can name classes in an RB diff.

Adds `fastlane/metadata/android/en-US/changelogs/20100300.txt`. Everything since v2.00.00 is dependency bumps, the SDK 37 / AGP 9 migration, the data-retention doc and build hardening — no feature changes — so it reads as a maintenance release.

### Verification

- YAML parses; all 11 `run:` blocks pass `bash -n`
- Version-computation logic extracted and executed against 9 input shapes: the 4 legitimate ones produce the expected name/code/tag, all 5 malformed ones are rejected with the intended error
- `:app:ktlintCheck :app:testDebugUnitTest` green locally

### Caveats

- **The certificate gate is untested against the real key** — I have no access to the keystore. If `6248657a…` (taken from the scanner output in #30) is wrong, the release hard-fails. That is the safe direction, but **run `2.01.00alpha1` first** as an end-to-end smoke test before the stable release.
- **The test gate is thin**: `testDebugUnitTest` runs 1 test, the default `ExampleUnitTest`. It guards the harness, not behaviour.

### Follow-ups not in this PR

- The orphan tags need deleting: `git push origin --delete refs/tags/v1.02.00 refs/tags/v1.03.00`
- After releasing, bump the `versionName` default in `build.gradle.kts` to the next dev cycle
- No CI workflow exists in this repo (only `release.yml`), which is how master reached a state where Gradle could not configure it — separate PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)
