### PR TITLE
chore: open 2.02 dev cycle

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -71,8 +71,8 @@ android {
         //
         // This ensures the correct ordering between the various types of releases (dev < alpha < beta < release) which is
         // needed for upgrades to be offered correctly.
-        versionCode = overrideVersionCode ?: 20100001
-        versionName = overrideVersionName ?: "2.01.00dev"
+        versionCode = overrideVersionCode ?: 20200001
+        versionName = overrideVersionName ?: "2.02.00dev"
 
         testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
         vectorDrawables {


### PR DESCRIPTION
Post-release bump of the fallback version, following the same shape as `a1ce0db` ("chore: open 2.01 dev cycle").

```
- versionCode = overrideVersionCode ?: 20100001
- versionName = overrideVersionName ?: "2.01.00dev"
+ versionCode = overrideVersionCode ?: 20200001
+ versionName = overrideVersionName ?: "2.02.00dev"
```

Beyond the routine bump, `20100001` is now actively harmful as a default: an Android Studio build picked it up and got as far as a Play upload, which Play rejected with *"Version code 20100001 has already been used"*. Any local `bundleRelease` would keep producing something Play refuses, and it silently disagrees with the `20100300` that 2.01.00 actually shipped as.

Verified: a plain `:app:assembleDebug` with no `-P` flags now reports `versionCode='20200001' versionName='2.02.00dev-debug'`.
